### PR TITLE
Improve setup command

### DIFF
--- a/secureenclave/utilities/setup.js
+++ b/secureenclave/utilities/setup.js
@@ -10,6 +10,8 @@ const firebase = require("firebase-admin");
 
 const db = firebase.firestore();
 
+require('../../applesilicon/embed.js')();
+
 const ios_database = db.collection('discord').doc('ios');
 const ipados_database = db.collection('discord').doc('ipados');
 const watchos_database = db.collection('discord').doc('watchos');
@@ -448,6 +450,6 @@ module.exports = {
             return message.channel.send(errorembed("I do not have the necessary permissions to work properly! \n\n ***Please make sure I have the following permissions:*** \n- View Channels\n- Add Reactions\n- Use External Emojis\n- Manage Messages"));
         }
 
-        (args[0] == "role") ? run_setup_roles(message, args).catch(function (error) { console.log(error) }) : run_setup_updates(message, args).catch(function (error) { console.log(error) });
+        (args[0] == "role") ? run_setup_roles(message, args).catch(function (error) { return message.channel.send(minor_error_embed(error)) }) : run_setup_updates(message, args).catch(function (error) { return message.channel.send(minor_error_embed(error)) });
     },
 };


### PR DESCRIPTION
Send error to channel instead of logging to console.

Not sure what you intended to do anyways, but I think this is a better solution for users to know why the command errors out.