### PR TITLE
Ability to get changelog for macos

### DIFF
--- a/applesilicon/main/gdmf.js
+++ b/applesilicon/main/gdmf.js
@@ -9,14 +9,16 @@ const doc_asset_type = {
     ios: "com.apple.MobileAsset.SoftwareUpdateDocumentation",
     ipados: "com.apple.MobileAsset.SoftwareUpdateDocumentation",
     audioos: "com.apple.MobileAsset.SoftwareUpdateDocumentation",
-    watchos: "com.apple.MobileAsset.WatchSoftwareUpdateDocumentation"
+    watchos: "com.apple.MobileAsset.WatchSoftwareUpdateDocumentation",
+    macos: "com.apple.MobileAsset.SoftwareUpdateDocumentation",
 }
 
 const device_name = {
     ios: "iPhone",
     ipados: "iPad",
     audioos: "AudioAccessory",
-    watchos: "Watch"
+    watchos: "Watch",
+    macos: "Mac"
 }
 
 module.exports = function () {


### PR DESCRIPTION
I've added the mac identifiers to allow the information of macOS changelog.

REST Test Preview:
[![image](https://user-images.githubusercontent.com/30329003/191394432-dbf37ff6-5e76-45e4-80c3-332cbe14fd36.png)](https://reqbin.com/lcwwlkaa)

(Click the image to open the reqbin.com link, if not copy & paste this one: `https://reqbin.com/lcwwlkaa`)

Json Preview: https://jsonformatter.org/b97f06

Changelog Download (from json preview): https://updates.cdn-apple.com/2022SummerSeed/patches/012-61481/511E6CEC-0C85-4EBC-9DC5-D7C91A1C3BB1/com_apple_MobileAsset_SoftwareUpdateDocumentation/2a4bfa49506ccd5fa641e6afb957d20c5ccbe6aa.zip

Preview of changelog:
![image](https://user-images.githubusercontent.com/30329003/191394919-cd0fb25a-9e6b-4436-99da-79d9cb7a13ad.png)

